### PR TITLE
Fix syntax errors in compiled html

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,7 +74,6 @@ const html = () => {
             removeComments: true,
             html5: true,
             removeEmptyAttributes: true,
-            removeTagWhitespace: true,
             sortAttributes: true,
             sortClassName: true
         }))

--- a/src/index.html
+++ b/src/index.html
@@ -24,9 +24,10 @@
 
     <!-- Content aus dem Tutorial: END -->
 
-</body>
 
-<!-- JS Import -->
-<script src="./js/main.bundle.js"></script>
+    <!-- JS Import -->
+    <script src="./js/main.bundle.js"></script>
+    
+</body>
 
 </html>


### PR DESCRIPTION
Fixes #23

Nicht alle Browser sind so intelligent wie Chrome und können mit Fehlern in der HTML Syntax umgehen (Wie im Issue beschrieben).

Was behoben wurde:
Laut [Spezifikation](https://validator.w3.org/) müssen zwischen Attributen Leerzeichen sein. Der HTML Minifizierer hat diese aber entfernt.
Ein Element in der index.html, das eigentlich in den ``<body>`` gehört, war nicht dort.